### PR TITLE
Add dedicated method for exception message

### DIFF
--- a/src/InvalidIndexRule.php
+++ b/src/InvalidIndexRule.php
@@ -6,4 +6,8 @@ use Exception;
 
 class InvalidIndexRule extends Exception
 {
+    public static function requiresBooleanOrString()
+    {
+        return new static('An indexing rule needs to return a boolean or a string.');
+    }
 }

--- a/src/RobotsMiddleware.php
+++ b/src/RobotsMiddleware.php
@@ -23,7 +23,7 @@ class RobotsMiddleware
             return $this->responseWithRobots($shouldIndex);
         }
 
-        throw new InvalidIndexRule('An indexing rule needs to return a boolean or a string');
+        throw InvalidIndexRule::requiresBooleanOrString();
     }
 
     protected function responseWithRobots(string $contents)


### PR DESCRIPTION
Just a small tip. Adding dedicated methods to your exceptions allows you to re-use them elsewhere when needed.

Good read on this by Ross Tuck: http://rosstuck.com/formatting-exception-messages/ :smile: 
